### PR TITLE
Add support for webhook modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,24 @@ $ ./discord.sh \
 
 ![](https://i.imgur.com/lni4fI3.png)
 
+### • `--modify`
+> You can permanently change the username and avatar of the webhook.
+> The following options are valid: `--username` and `--modify`
+
+> **Warning:**
+> No other options may be passed, including those for sending messages.
+
+#### Example
+```bash
+$ ./discord.sh \
+  --modify \
+  --username "NotifBot" \
+  --avatar "https://i.imgur.com/12jyR5Q.png" 
+```
+
+Once executed, all other webhook messages by default will contain the username and avatar set.
+
+![](https://i.imgur.com/ZYUBiil.png)
 ## Advanced Options
 
 Now we're going to look at how to setup a custom embed message.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
 - [bats][bats] (tests)
 - [curl][curl] (http requests)
 - [jq][jq] (JSON parsing)
+- [base64][base64] (webhook avatar modification)
+- [file][file] (MIME type retrieval for webhook avatar modification)
 
 ## Usage
 
@@ -318,6 +320,8 @@ Made with 💖 by [ChaoticWeg][weg] & [fieu][fieu] || Documentation and design b
 [cut]: https://linux.die.net/man/1/cut
 [coreutils]: https://www.gnu.org/software/coreutils/coreutils.html
 [util-linux]: https://en.wikipedia.org/wiki/Util-linux
+[base64]: https://wiki.openssl.org/index.php/Command_Line_Utilities#Base64_Encoding_Strings
+[file]: https://github.com/file/file
 <!-- Documentation -->
 [webhook]: https://support.discordapp.com/hc/en-us/articles/228383668-Intro-to-Webhooks
 <!--  Contributors -->

--- a/tests/04.modify.bats
+++ b/tests/04.modify.bats
@@ -13,8 +13,16 @@ load pre
     run bash discord.sh --modify --username "Modify with username"
     [ "$status" -eq 0 ]
 }
+@test "modify: verify --modify ---username --gnu-style <>" {
+    run bash discord.sh --text "verify"
+    [ "$status" -eq 0 ]
+}
 @test "modify: --modify --username --gnu-style=<>" {
     run bash discord.sh --modify --username="Modify with username"
+    [ "$status" -eq 0 ]
+}
+@test "modify: verify --modify ---username --gnu-style=<>" {
+    run bash discord.sh --text "verify"
     [ "$status" -eq 0 ]
 }
 # Modify with avatar
@@ -22,8 +30,16 @@ load pre
     run bash discord.sh --modify --avatar "https://i.imgur.com/12jyR5Q.png"
     [ "$status" -eq 0 ]
 }
+@test "modify: verify --modify ---avatar --gnu-style <>" {
+    run bash discord.sh --text "verify"
+    [ "$status" -eq 0 ]
+}
 @test "modify: --modify --avatar --gnu-style=<>" {
     run bash discord.sh --modify --avatar="https://i.imgur.com/12jyR5Q.png"
+    [ "$status" -eq 0 ]
+}
+@test "modify: verify --modify ---avatar --gnu-style=<>" {
+    run bash discord.sh --text "verify"
     [ "$status" -eq 0 ]
 }
 # Modify with username and avatar
@@ -31,11 +47,23 @@ load pre
     run bash discord.sh --modify --username "Modify with username and avatar" --avatar "https://i.imgur.com/12jyR5Q.png"
     [ "$status" -eq 0 ]
 }
+@test "modify: verify --modify --username --avatar --gnu-style <>" {
+    run bash discord.sh --text "verify"
+    [ "$status" -eq 0 ]
+}
 @test "modify: --modify --username --avatar --gnu-style=<>" {
     run bash discord.sh --modify --username "Modify with username and avatar" --avatar "https://i.imgur.com/12jyR5Q.png"
     [ "$status" -eq 0 ]
 }
+@test "modify: verify --modify --username --avatar --gnu-style=<>" {
+    run bash discord.sh --text "verify"
+    [ "$status" -eq 0 ]
+}
 @test "modify: --modify --username --avatar --gnu-style varied" {
     run bash discord.sh --modify --username "Modify with username and avatar" --avatar="https://i.imgur.com/12jyR5Q.png"
+    [ "$status" -eq 0 ]
+}
+@test "modify: verify --modify --username --avatar --gnu-style varied" {
+    run bash discord.sh --text "verify"
     [ "$status" -eq 0 ]
 }

--- a/tests/04.modify.bats
+++ b/tests/04.modify.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+load pre
+
+# Modify without username or avatar
+@test "modify: --modify (should fail)" {
+    run bash discord.sh --modify
+    [ "${lines[0]}" = "fatal: must pass --username or --avatar with --modify" ]
+    [ "$status" -eq 1 ]
+}
+# Modify with username
+@test "modify: --modify --username --gnu-style <>" {
+    run bash discord.sh --modify --username "Modify with username"
+    [ "$status" -eq 0 ]
+}
+@test "modify: --modify --username --gnu-style=<>" {
+    run bash discord.sh --modify --username="Modify with username"
+    [ "$status" -eq 0 ]
+}
+# Modify with avatar
+@test "modify: --modify --avatar --gnu-style <>" {
+    run bash discord.sh --modify --avatar "https://i.imgur.com/12jyR5Q.png"
+    [ "$status" -eq 0 ]
+}
+@test "modify: --modify --avatar --gnu-style=<>" {
+    run bash discord.sh --modify --avatar="https://i.imgur.com/12jyR5Q.png"
+    [ "$status" -eq 0 ]
+}
+# Modify with username and avatar
+@test "modify: --modify --username --avatar --gnu-style <>" {
+    run bash discord.sh --modify --username "Modify with username and avatar" --avatar "https://i.imgur.com/12jyR5Q.png"
+    [ "$status" -eq 0 ]
+}
+@test "modify: --modify --username --avatar --gnu-style=<>" {
+    run bash discord.sh --modify --username "Modify with username and avatar" --avatar "https://i.imgur.com/12jyR5Q.png"
+    [ "$status" -eq 0 ]
+}
+@test "modify: --modify --username --avatar --gnu-style varied" {
+    run bash discord.sh --modify --username "Modify with username and avatar" --avatar="https://i.imgur.com/12jyR5Q.png"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
This PR adds support for webhook modification.

1 new option has been added:
- `--modify` - This is a boolean option that once set, changes the behavior of `--username` and `--avatar` to conform to the API request needed to modify a webhook.