### PR TITLE
fix: use portable syntax to strip trailing comma in build_fields

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -124,7 +124,7 @@ add_field() {
 }
 
 build_fields() {
-    echo ", \"fields\": [${fields::-1} ]"
+    echo ", \"fields\": [${fields%,} ]"
 }
 
 print_version() {
@@ -199,8 +199,8 @@ while (( "$#" )); do
         --image*) embed_imageurl=${2}; embedding=1; shift; shift;;
 
         # fields
-        --field=*) add_field "${1/--field=/''}"; embedding=1; shift;;
-        --field*) add_field "${2}"; embedding=1; shift; shift;;
+        --field=*) embedding=1; add_field "${1/--field=/''}"; shift;;
+        --field*) embedding=1; add_field "${2}"; shift; shift;;
 
         # footer
         --footer-icon=*) embed_footericon=${1/--footer-icon=/''}; embedding=1; shift;;


### PR DESCRIPTION
This PR fixes two bugs that together made `--field` completely non-functional.

## Bug 1: `add_field` always exited early

`add_field` guards against being called outside of an embed context:

```bash
[[ -z "${embedding}" ]] && exit;
```

However, in the argument parser, `embedding=1` was set *after* calling `add_field`:

```bash
--field*) add_field "${2}"; embedding=1; shift; shift;;
```

This meant that when `--field` was the first (or only) embed-related flag, `embedding` was still unset when `add_field` ran, causing it to exit immediately without appending anything to `fields`.

**Fix:** swapped the order so `embedding=1` is set before `add_field` is called.

---

## Bug 2: `${fields::-1}` silently fails on bash < 4.2

`build_fields` used `${fields::-1}` to strip the trailing comma from the accumulated field entries. This negative-length substring expansion requires **bash 4.2+** and silently produces no output on macOS, which ships with **bash 3.2** by default.

As a result, `_fields` was always assigned an empty string inside `build_embed`, and the `"fields"` key never appeared in the embed JSON — making `--field` a no-op on any system running bash < 4.2.

**Fix:** replaced `${fields::-1}` with `${fields%,}`, which strips the trailing comma using suffix pattern removal — a POSIX-compatible feature available in all bash versions.
